### PR TITLE
Add to queue radio buttons text is now clickable

### DIFF
--- a/app/app/templates/home.html
+++ b/app/app/templates/home.html
@@ -103,10 +103,8 @@ content %}
 				<input type="text" id="unitCode" minlength="8" maxlength="8" class="form-control" required />
 				<div class="form-group-lg">
 					<label><b>Team</b></label><br>
-					<input type="radio" id="queue" name="queueSelector" value="STUDYSmarter" checked>
-					<label for="STUDYSmarter">STUDYSmarter</label><br>
-					<input type="radio" id="queue" name="queueSelector" value="Librarian">
-					<label for="Librarian">Librarian</label><br>
+					<label><input type="radio" id="queue" name="queueSelector" value="STUDYSmarter" checked>STUDYSmarter</label><br>
+					<label><input type="radio" id="queue" name="queueSelector" value="Librarian">Librarian</label><br>
 				</div>
 				<div class="form-group-lg">
 					<label for="enquiry"><b>Enquiry Type</b></label>


### PR DESCRIPTION

## Change Summary
Add to queue radio buttons text can now be clicked to select them


- [X] The pull request title has an issue number
- [X] The code works by "Smoke testing" (in other words, you have tested it your own and it works)
- [ ] The code has documentation (either comments or in main documentation platform)

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**